### PR TITLE
add validation, deduplicated rows, added summary.json output

### DIFF
--- a/read_people.py
+++ b/read_people.py
@@ -1,6 +1,5 @@
 import csv
 import json
-import os
 
 rows_read = 0
 rows_kept = []

--- a/read_people.py
+++ b/read_people.py
@@ -1,0 +1,82 @@
+import csv
+import json
+import os
+
+rows_read = 0
+rows_kept = []
+seen_emails = set()
+rows_rejected = 0
+people_per_city = {}
+name_email_pairs = []
+reject_reasons_rows = []
+reject_reasons = {}
+duplicates_found = 0
+
+with open("warmup-data/people.csv", newline='') as csvfile:
+    reader = csv.DictReader(csvfile)
+
+    for row in reader:
+        rows_read += 1
+
+        name = row["name"].strip()
+        email = row["email"].strip().lower()
+        city = row["city"].strip()
+        age = row["age"].strip()
+
+        # if email not in seen_emails:
+        seen_emails.add(email)
+
+        if not name:
+            rows_rejected += 1
+            reject_reasons_rows.append((row, "empty name"))
+            if "empty name" in reject_reasons:
+                reject_reasons["empty name"] += 1
+            else:
+                reject_reasons["empty name"] = 1
+
+        if not age.isdigit():
+            rows_rejected += 1
+            reject_reasons_rows.append((row, "age not a number"))
+            if "age not a number" in reject_reasons:
+                reject_reasons["age not a number"] += 1
+            else:
+                reject_reasons["age not a number"] = 1
+            continue
+
+        elif not 18 <= int(age) <= 120:
+            rows_rejected += 1
+            reject_reasons_rows.append((row, "age out of range"))
+            if "age out of range" in reject_reasons:
+                reject_reasons["age out of range"] += 1
+                continue
+            reject_reasons["age out of range"] = 1
+
+        if not city:
+            city = "unknown"
+            row["city"] = city
+
+        name_email_pairs.append((name, email))
+        if city in people_per_city:
+            people_per_city[city] += 1
+
+        else:
+            people_per_city[city] = 1
+
+        rows_kept.append(row)
+
+summary = {
+    "rows_read": rows_read,
+    "rows_kept": len(rows_kept),
+    "rows_rejected": rows_rejected,
+    "duplicates_found": rows_read - len(seen_emails),
+    "reject_reasons": {
+        "empty name": reject_reasons["empty name"],
+        "age not a number": reject_reasons["age not a number"],
+        "age out of range": reject_reasons["age out of range"],
+    },
+    "cities_count": len(people_per_city),
+    "people_per_city": dict(sorted(people_per_city.items()))
+}
+
+with open("summary.json", "w") as output:
+    json.dump(summary, output, indent=2)

--- a/warmup/01_read_csv/read_people.py
+++ b/warmup/01_read_csv/read_people.py
@@ -8,11 +8,11 @@ rows_read = 0
 rows_kept = []
 seen_emails = set()
 
-people_per_city: dict[str,int] = {}
+people_per_city: dict[str, int] = {}
 name_email_pairs = []
 
 reject_reasons_rows = []
-reject_reasons: dict[str,int] = {}
+reject_reasons: dict[str, int] = {}
 duplicates_found = 0
 
 people_csv = "../../warmup-data/people.csv"
@@ -87,7 +87,7 @@ summary = {
         "age out of range": reject_reasons["age out of range"],
     },
     "cities_count": len(people_per_city),
-    "people_per_city": dict(sorted(people_per_city.items()))
+    "people_per_city": dict(sorted(people_per_city.items())),
 }
 
 with Path(summary_json).open("w") as output:

--- a/warmup/01_read_csv/read_people.py
+++ b/warmup/01_read_csv/read_people.py
@@ -4,14 +4,15 @@ import json
 rows_read = 0
 rows_kept = []
 seen_emails = set()
-rows_rejected = 0
 people_per_city = {}
 name_email_pairs = []
 reject_reasons_rows = []
 reject_reasons = {}
 duplicates_found = 0
+people_csv = "../../warmup-data/people.csv"
+summary_json = "../../warmup/01_read_csv/summary.json"
 
-with open("../../warmup-data/people.csv", newline='') as csvfile:
+with open(people_csv, newline='') as csvfile:
     reader = csv.DictReader(csvfile)
 
     for row in reader:
@@ -22,52 +23,55 @@ with open("../../warmup-data/people.csv", newline='') as csvfile:
         city = row["city"].strip()
         age = row["age"].strip()
 
-        # if email not in seen_emails:
+        if email in seen_emails:
+            continue
         seen_emails.add(email)
 
         if not name:
-            rows_rejected += 1
             reject_reasons_rows.append((row, "empty name"))
             if "empty name" in reject_reasons:
                 reject_reasons["empty name"] += 1
             else:
                 reject_reasons["empty name"] = 1
+            continue
 
-        if not age.isdigit():
-            rows_rejected += 1
+        try:
+            age = int(age)
+        except ValueError:
             reject_reasons_rows.append((row, "age not a number"))
             if "age not a number" in reject_reasons:
                 reject_reasons["age not a number"] += 1
             else:
                 reject_reasons["age not a number"] = 1
             continue
-
-        elif not 18 <= int(age) <= 120:
-            rows_rejected += 1
-            reject_reasons_rows.append((row, "age out of range"))
-            if "age out of range" in reject_reasons:
-                reject_reasons["age out of range"] += 1
-                continue
-            reject_reasons["age out of range"] = 1
-
-        if not city:
-            city = "unknown"
-            row["city"] = city
-
-        name_email_pairs.append((name, email))
-        if city in people_per_city:
-            people_per_city[city] += 1
-
         else:
-            people_per_city[city] = 1
+            if not 18 <= age <= 120:
+                reject_reasons_rows.append((row, "age out of range"))
+                if "age out of range" in reject_reasons:
+                    reject_reasons["age out of range"] += 1
+                else:
+                    reject_reasons["age out of range"] = 1
+                continue
 
-        rows_kept.append(row)
+            if not city:
+                city = "unknown"
+                row["city"] = city
+            name_email_pairs.append((name, email))
+            if city in people_per_city:
+                people_per_city[city] += 1
+            else:
+                people_per_city[city] = 1
+            rows_kept.append(row)
+
+duplicates = rows_read - len(seen_emails)
+rows_rejected = sum(reject_reasons.values())
+kept = rows_read - duplicates - rows_rejected
 
 summary = {
     "rows_read": rows_read,
-    "rows_kept": len(rows_kept),
+    "rows_kept": kept,
     "rows_rejected": rows_rejected,
-    "duplicates_found": rows_read - len(seen_emails),
+    "duplicates_found": duplicates,
     "reject_reasons": {
         "empty name": reject_reasons["empty name"],
         "age not a number": reject_reasons["age not a number"],
@@ -77,5 +81,5 @@ summary = {
     "people_per_city": dict(sorted(people_per_city.items()))
 }
 
-with open("../../warmup/01_read_csv/summary.json", "w") as output:
+with open(summary_json, "w") as output:
     json.dump(summary, output, indent=2)

--- a/warmup/01_read_csv/read_people.py
+++ b/warmup/01_read_csv/read_people.py
@@ -1,18 +1,27 @@
+"""Read people.csv, validate rows, and write summary.json."""
+
 import csv
 import json
+from pathlib import Path
 
 rows_read = 0
 rows_kept = []
 seen_emails = set()
-people_per_city = {}
+
+people_per_city: dict[str,int] = {}
 name_email_pairs = []
+
 reject_reasons_rows = []
-reject_reasons = {}
+reject_reasons: dict[str,int] = {}
 duplicates_found = 0
+
 people_csv = "../../warmup-data/people.csv"
 summary_json = "../../warmup/01_read_csv/summary.json"
 
-with open(people_csv, newline='') as csvfile:
+MIN_AGE = 18
+MAX_AGE = 120
+
+with Path(people_csv).open() as csvfile:
     reader = csv.DictReader(csvfile)
 
     for row in reader:
@@ -45,7 +54,7 @@ with open(people_csv, newline='') as csvfile:
                 reject_reasons["age not a number"] = 1
             continue
         else:
-            if not 18 <= age <= 120:
+            if not MIN_AGE <= age <= MAX_AGE:
                 reject_reasons_rows.append((row, "age out of range"))
                 if "age out of range" in reject_reasons:
                     reject_reasons["age out of range"] += 1
@@ -81,5 +90,5 @@ summary = {
     "people_per_city": dict(sorted(people_per_city.items()))
 }
 
-with open(summary_json, "w") as output:
+with Path(summary_json).open("w") as output:
     json.dump(summary, output, indent=2)

--- a/warmup/01_read_csv/read_people.py
+++ b/warmup/01_read_csv/read_people.py
@@ -11,7 +11,7 @@ reject_reasons_rows = []
 reject_reasons = {}
 duplicates_found = 0
 
-with open("warmup-data/people.csv", newline='') as csvfile:
+with open("../../warmup-data/people.csv", newline='') as csvfile:
     reader = csv.DictReader(csvfile)
 
     for row in reader:
@@ -77,5 +77,5 @@ summary = {
     "people_per_city": dict(sorted(people_per_city.items()))
 }
 
-with open("summary.json", "w") as output:
+with open("../../warmup/01_read_csv/summary.json", "w") as output:
     json.dump(summary, output, indent=2)

--- a/warmup/01_read_csv/read_people.py
+++ b/warmup/01_read_csv/read_people.py
@@ -81,11 +81,7 @@ summary = {
     "rows_kept": kept,
     "rows_rejected": rows_rejected,
     "duplicates_found": duplicates,
-    "reject_reasons": {
-        "empty name": reject_reasons["empty name"],
-        "age not a number": reject_reasons["age not a number"],
-        "age out of range": reject_reasons["age out of range"],
-    },
+    "reject_reasons": {**reject_reasons},
     "cities_count": len(people_per_city),
     "people_per_city": dict(sorted(people_per_city.items())),
 }


### PR DESCRIPTION
## What this changes
Reads _people.csv_, validates each row (name age format age range), skips duplicate emails, and outputs city counts to _summary.json_.

Closes #2 

## How I tested it

1. Ran "python read_people.py" in PyCharm.
2. Verified summary.json matches the required output exactly:
{
  "rows_read": 17,
  "rows_kept": 14,
  "rows_rejected": 6,
  "duplicates_found": 2,
  "reject_reasons": {
    "empty name": 2,
    "age not a number": 2,
    "age out of range": 2
  },
  "cities_count": 5,
  "people_per_city": {
    "Bristol": 3,
    "Leeds": 2,
    "London": 5,
    "Manchester": 3,
    "unknown": 1
  }
}

## Anything I was unsure about

- Whether age range (18-120) is inclusive or exclusive - I assumed it is inclusive since it makes more sense than having 19-121 as an age range.
- Whether the **people_per_city** dictionary needed to be alphabetically sorted or if key order didn't matter to validation, but I realised that the expected output is alphabetically sorted therefore had to add the method in the end.

## Checklist

- I can explain every line in this pull request out loud
- No passwords, keys or personal data, and no data files committed
- "ruff check ." is clean:
<img width="529" height="56" alt="image" src="https://github.com/user-attachments/assets/771ba8f7-5dbc-47c6-9b1f-550543aace5f" />

- No "print()" left behind
- Every acceptance criterion on the ticket is ticked
