### PR TITLE
Add branch protection ruleset for main

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,17 @@
+# Branch rulesets
+
+`main-ruleset.json` protects the `main` branch. Once applied, every change to
+`main` must go through a pull request with one approving review from someone
+other than the author, the `ruff` and `mypy` checks must pass before merging,
+and force-pushes and branch deletion are blocked. There are no bypass actors,
+so the rules apply to repository admins as well.
+
+Applying the ruleset requires admin access on the repository. Either import
+it through the web interface under Settings > Rules > Rulesets > New ruleset >
+Import a ruleset by uploading this file, or create it with the GitHub CLI:
+
+    gh api -X POST repos/danzgeorg/FastCore/rulesets \
+      --input .github/rulesets/main-ruleset.json
+
+Changes to the ruleset should be edited here first and re-applied, so this
+file stays the source of truth for how `main` is protected.

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -2,9 +2,19 @@
 
 `main-ruleset.json` protects the `main` branch. Once applied, every change to
 `main` must go through a pull request with one approving review from someone
-other than the author, the `ruff` and `mypy` checks must pass before merging,
-and force-pushes and branch deletion are blocked. There are no bypass actors,
-so the rules apply to repository admins as well.
+other than the author, and the `ruff` and `mypy` checks must pass before
+merging. Force-pushes to `main` are blocked: a force-push (`git push --force`)
+replaces commits that already exist on the remote with rewritten ones instead
+of adding on top of them, so blocking it keeps the history of `main`
+append-only. Deleting the `main` branch itself is also blocked. There are no
+bypass actors, so the rules apply to repository admins as well.
+
+Only `main` is covered. Every other branch behaves exactly as before:
+contributors can create, rename, force-push and delete their own feature
+branches freely, including deleting a mis-created branch or cleaning up a
+branch after its pull request has been merged. Merging never deletes the
+source branch by itself; that is always a separate step, and it stays allowed
+for everything except `main`.
 
 Applying the ruleset requires admin access on the repository. Either import
 it through the web interface under Settings > Rules > Rulesets > New ruleset >

--- a/.github/rulesets/main-ruleset.json
+++ b/.github/rulesets/main-ruleset.json
@@ -1,0 +1,38 @@
+{
+  "name": "Protect main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "ruff" },
+          { "context": "mypy" }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What this changes

Adds `.github/rulesets/main-ruleset.json`, the source of truth for the "Protect main" ruleset that is now active on the repository, plus a README explaining what it enforces and how an admin re-applies it after edits. No behaviour change by itself; the ruleset was already applied from this file.

## How I tested it

The ruleset was created from this exact JSON and verified live via `gh api repos/danzgeorg/FastCore/rules/branches/main`, which returns all four rules (pull request with one approval, required ruff and mypy checks, no force-pushes, no deletion) from ruleset 21402810.

## Anything I was unsure about

Nothing to guess at in the JSON itself, but this PR doubles as the first live test of the new protections: it should be unmergeable until CI is green and it has an approval from someone other than the author.

## Checklist

- [x] I can explain every line in this pull request out loud
- [x] No passwords, keys or personal data, and no data files committed
- [x] `ruff check .` is clean
- [x] No `print()` left behind
- [x] Every acceptance criterion on the ticket is ticked