### PR TITLE
Warmup 3 register form

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dev = [
     "fastapi",
     "uvicorn",
     "python-multipart",
-    "email-validaor",
+    "email-validator",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@
 dev = [
     "ruff==0.16.4",
     "mypy==2.3.1",
+    "fastapi",
+    "uvicorn",
+    "python-multipart",
+    "email-validaor",
 ]
 
 [tool.mypy]

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -34,7 +34,6 @@ def register_user(
     email: Annotated[str, Form()], password: Annotated[str, Form()], city: Annotated[str, Form()]
 ) -> dict:
     """Register a new user."""
-
     email = email.lower()
 
     if not email or not password:

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -34,10 +34,10 @@ def get_website() -> FileResponse:
 @app.post("/register")
 def register_user(
     email: Annotated[str, Form()], password: Annotated[str, Form()], city: Annotated[str, Form()]
-) -> dict:
+) -> dict[str, str]:
     """Register a new user."""
     if not email or not password:
-        raise HTTPException (status_code=400, detail = "Email and password are required.")
+        raise HTTPException (status_code=400, detail="Email and password are required.")
 
     try:
         validate_email(email)

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import secrets
 from typing import Annotated
 
+from email_validator import EmailNotValidError
+from email_validator import validate_email
 from fastapi import FastAPI
 from fastapi import Form
 from fastapi import HTTPException
@@ -34,21 +36,27 @@ def register_user(
     email: Annotated[str, Form()], password: Annotated[str, Form()], city: Annotated[str, Form()]
 ) -> dict:
     """Register a new user."""
-    email = email.lower()
-
     if not email or not password:
-        return {"error": "Email and password are required."}
+        raise HTTPException (status_code=400, detail = "Email and password are required.")
+
+    try:
+        validate_email(email)
+    except EmailNotValidError:
+        raise HTTPException(status_code=400, detail="Invalid email address.") from None
 
     # load existing users from file
     if users_file.exists():
-        with users_file.open() as f:
-            users = json.load(f)
+        try:
+            with users_file.open() as f:
+                users = json.load(f)
+        except json.JSONDecodeError:
+            users = []
     else:
         users = []
 
     # check if email already exists
     for user in users:
-        if user["email"] == email:
+        if user["email"].lower() == email.lower():
             raise HTTPException(status_code=409, detail="Email already registered.")
 
     # hash the password

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -5,7 +5,6 @@ Passwords are hashed and a random salt before saving to file. The password is ne
 emails are rejected with 409 and message. No validation is done yet.
 """
 
-
 import hashlib
 import json
 from pathlib import Path
@@ -23,17 +22,19 @@ app = FastAPI()
 website = "static/register.html"
 users_file = Path("users.json")
 
+
 @app.get("/")
 def get_website() -> FileResponse:
     """Serve the registration form."""
     return FileResponse(website)
 
+
 @app.post("/register")
 def register_user(
-        email: Annotated[str, Form()],
-        password: Annotated[str, Form()],
-        city: Annotated[str, Form()]) -> dict:
+    email: Annotated[str, Form()], password: Annotated[str, Form()], city: Annotated[str, Form()]
+) -> dict:
     """Register a new user."""
+
     email = email.lower()
 
     if not email or not password:
@@ -64,4 +65,3 @@ def register_user(
         json.dump(users, f, indent=4)
 
     return {"email": email, "city": city}
-

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -1,30 +1,48 @@
+"""
+Static HTML registration form with FastAPI POST endpoint.
+
+Passwords are hashed and a random salt before saving to file. The password is never returned in the response. Duplicate
+emails are rejected with 409 and message. No validation is done yet.
+"""
+
+
+import hashlib
+import json
+from pathlib import Path
+import secrets
+from typing import Annotated
+
 from fastapi import FastAPI
 from fastapi import Form
 from fastapi import HTTPException
 from fastapi.responses import FileResponse
-import json
-import os
-import secrets
-import hashlib
 
+# create FastAPI app
 app = FastAPI()
 
 website = "static/register.html"
+users_file = Path("users.json")
 
 @app.get("/")
 def get_website() -> FileResponse:
+    """Serve the registration form."""
     return FileResponse(website)
 
 @app.post("/register")
-def register_user(email: str = Form(...), password: str = Form(...), city: str = Form(...)):
+def register_user(
+        email: Annotated[str, Form()],
+        password: Annotated[str, Form()],
+        city: Annotated[str, Form()]) -> dict:
+    """Register a new user."""
     email = email.lower()
+
     if not email or not password:
         return {"error": "Email and password are required."}
 
     # load existing users from file
-    if os.path.exists("users.json"):
-        with open("users.json", "r") as users_file:
-            users = json.load(users_file)
+    if users_file.exists():
+        with users_file.open() as f:
+            users = json.load(f)
     else:
         users = []
 
@@ -42,8 +60,8 @@ def register_user(email: str = Form(...), password: str = Form(...), city: str =
     # save user to file
     new_user = {"email": email, "salt": salt_hex, "hash": hash_hex, "city": city}
     users.append(new_user)
-    with open("users.json", "w") as users_file:
-        json.dump(users, users_file, indent=4)
+    with users_file.open("w") as f:
+        json.dump(users, f, indent=4)
 
     return {"email": email, "city": city}
 

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -1,0 +1,49 @@
+from fastapi import FastAPI
+from fastapi import Form
+from fastapi import HTTPException
+from fastapi.responses import FileResponse
+import json
+import os
+import secrets
+import hashlib
+
+app = FastAPI()
+
+website = "static/register.html"
+
+@app.get("/")
+def get_website() -> FileResponse:
+    return FileResponse(website)
+
+@app.post("/register")
+def register_user(email: str = Form(...), password: str = Form(...), city: str = Form(...)):
+    email = email.lower()
+    if not email or not password:
+        return {"error": "Email and password are required."}
+
+    # load existing users from file
+    if os.path.exists("users.json"):
+        with open("users.json", "r") as users_file:
+            users = json.load(users_file)
+    else:
+        users = []
+
+    # check if email already exists
+    for user in users:
+        if user["email"] == email:
+            raise HTTPException(status_code=409, detail="Email already registered.")
+
+    # hash the password
+    salt = secrets.token_bytes(16)
+    hashed_password = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, 100_000)
+    salt_hex = salt.hex()
+    hash_hex = hashed_password.hex()
+
+    # save user to file
+    new_user = {"email": email, "salt": salt_hex, "hash": hash_hex, "city": city}
+    users.append(new_user)
+    with open("users.json", "w") as users_file:
+        json.dump(users, users_file, indent=4)
+
+    return {"email": email, "city": city}
+

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -37,7 +37,7 @@ def register_user(
 ) -> dict[str, str]:
     """Register a new user."""
     if not email or not password:
-        raise HTTPException (status_code=400, detail="Email and password are required.")
+        raise HTTPException(status_code=400, detail="Email and password are required.")
 
     try:
         validate_email(email)

--- a/warmup/03_webapp/static/register.html
+++ b/warmup/03_webapp/static/register.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<form action="/register" method="post" class="register-form">
+  <div class="register-form">
+    <label for="email">Enter your email: </label>
+    <input type="text" name="email" id="email" required />
+  </div>
+  <div class="register-form">
+    <label for="password">Enter your password: </label>
+    <input type="password" name="password" id="password" required />
+  </div>
+  <div class="register-form">
+    <label for="city">Enter your city: </label>
+    <input type="text" name="city" id="city" required />
+  </div>
+  <div class="register-form">
+    <input type="submit" value="Submit" />
+  </div>
+</form>
+
+</html>

--- a/warmup/03_webapp/static/register.html
+++ b/warmup/03_webapp/static/register.html
@@ -4,7 +4,7 @@
 <form action="/register" method="post" class="register-form">
   <div class="register-form">
     <label for="email">Enter your email: </label>
-    <input type="text" name="email" id="email" required />
+    <input type="email" name="email" id="email" required />
   </div>
   <div class="register-form">
     <label for="password">Enter your password: </label>


### PR DESCRIPTION
## What this changes

Adds a static HTML registration form (email, password, city) and a `POST /register` endpoint that hashes password (SHA256 with random salt) and saves user to `users.json`, rejecting duplicate emails with a `409`.

Closes #4 

## How I tested it

1. Ran `uvicorn main:app --reload`:
<img width="596" height="92" alt="image" src="https://github.com/user-attachments/assets/4d645196-c8c2-4928-9bf3-91ddce6b7b4f" />

2. Opened `http://127.0.0.1:8000` and submitted the form. Got back the JSON response with email and city, **no password/hash/salt** in it:
<img width="529" height="180" alt="image" src="https://github.com/user-attachments/assets/670c0eb8-6080-44cf-acf0-60b568dc253e" />

3. Checked `users.json`:
```
[
    {
        "email": "danzgeorg.contact@gmail.com",
        "salt": "d908653d5165c98366de8d0a8f804e0b",
        "hash": "dc48b66dab18edb180bc0673c16a0d6dd9b0485e83a821a405901b3a9cfbefc9",
        "city": "london"
    }
]
```

4. Submitted the same email again and got a return message with the Network tab `409` error which confirms its a real error not just message text and `users.json` didn't add an entry:
<img width="514" height="187" alt="image" src="https://github.com/user-attachments/assets/ddc598cb-413b-4ab6-b3ad-746c5bd9e37a" />
<img width="559" height="63" alt="image" src="https://github.com/user-attachments/assets/2484899c-7c65-4820-9ca7-2cdadf656222" />
<img width="864" height="311" alt="image" src="https://github.com/user-attachments/assets/bed1a1f9-59cb-47bb-881e-1905fa79d067" />

5. Ran `ruff check --fix` and fixed everything it flagged (missing docstring at the top of main.py and the functions, return type, FastAPI Form params not using Annoted library)


## Anything I was unsure about

- I didn't know whether to add email format and password strength validation since it doesn't specify whether it should be added.
- I know the read-modify-write on users.json isn't safe if 2 requests hit /register at the same time as the second request will overwrite the first, but how is that prevented or what is the decision that I should make to avoid that?
- I left password hashing after the duplicate email check so it never runs on a duplicate right now, but will it be broken when we refactor code in the later tickets?

## Checklist

- [x] I can explain every line in this pull request out loud
- [x] No passwords, keys or personal data, and no data files committed
- [x] `ruff check .` is clean
- [x] No `print()` left behind
- [x] Every acceptance criterion on the ticket is ticked