### PR TITLE
Warmup 4 login json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dev = [
 [tool.mypy]
 python_version = "3.14"
 strict = true
+# Should I add plugins = ["pydantic.mypy"] to resolve the mypy issue?
 # Strictness beyond --strict: forbid Any in any form and flag dead code.
 warn_unreachable = true
 disallow_any_explicit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,16 +4,16 @@
 dev = [
     "ruff==0.16.4",
     "mypy==2.3.1",
-    "fastapi",
-    "uvicorn",
-    "python-multipart",
-    "email-validator",
+    "fastapi==0.141.1",
+    "uvicorn==0.52.4",
+    "python-multipart==0.0.32",
+    "email-validator==2.3.0",
 ]
 
 [tool.mypy]
 python_version = "3.14"
 strict = true
-# Should I add plugins = ["pydantic.mypy"] to resolve the mypy issue?
+plugins = ["pydantic.mypy"]
 # Strictness beyond --strict: forbid Any in any form and flag dead code.
 warn_unreachable = true
 disallow_any_explicit = true

--- a/warmup/03_webapp/README.md
+++ b/warmup/03_webapp/README.md
@@ -1,0 +1,15 @@
+# 03_webapp
+
+Warmup exercises building a small FastAPI app: a registration form
+(warmup 3) and a JSON login endpoint (warmup 4).
+
+## Authentication
+
+Login checks the submitted password against the stored hash and salt for
+that email, and returns 200 (with email and city) or 401. That is all it
+does.
+
+There is no session, no token set anywhere in this project.
+
+This is not real authentication. It is verifying a password safely with the rest deliberately left out for a
+future ticket.

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 import secrets
 from typing import Annotated
+from typing import cast
 
 from email_validator import EmailNotValidError
 from email_validator import validate_email
@@ -42,9 +43,10 @@ def load_users() -> list[dict[str, str]]:
     if users_file.exists():
         try:
             with users_file.open() as f:
-                return json.load(f)
+                data = json.load(f)
         except json.JSONDecodeError:
             return []
+        return cast(list[dict[str, str]], data)
     return []
 
 

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -26,7 +26,7 @@ from pydantic import EmailStr
 app = FastAPI()
 
 
-class LoginRequest(BaseModel):
+class LoginRequest(BaseModel):  # type: ignore[explicit-any]
     """Shape of the JSON request body."""
 
     email: EmailStr

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -26,7 +26,7 @@ from pydantic import EmailStr
 app = FastAPI()
 
 
-class LoginRequest(BaseModel):
+class LoginRequest(BaseModel): # type: ignore[explicit-any]
     """Shape of the JSON request body."""
 
     email: EmailStr

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -46,7 +46,7 @@ def load_users() -> list[dict[str, str]]:
                 data = json.load(f)
         except json.JSONDecodeError:
             return []
-        return cast(list[dict[str, str]], data)
+        return cast("list[dict[str, str]]", data)
     return []
 
 

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -26,7 +26,7 @@ from pydantic import EmailStr
 app = FastAPI()
 
 
-class LoginRequest(BaseModel):  # type: ignore[explicit-any]
+class LoginRequest(BaseModel):
     """Shape of the JSON request body."""
 
     email: EmailStr

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import secrets
 from typing import Annotated
 
+from pydantic import BaseModel
+from pydantic import EmailStr
 from email_validator import EmailNotValidError
 from email_validator import validate_email
 from fastapi import FastAPI
@@ -21,14 +23,26 @@ from fastapi.responses import FileResponse
 # create FastAPI app
 app = FastAPI()
 
-website = "static/register.html"
+class LoginRequest(BaseModel):
+    """Shape of the JSON request body."""
+    email: EmailStr
+    password: str
+
+register = "static/register.html"
+login = "static/login.html"
 users_file = Path("users.json")
 
 
 @app.get("/")
 def get_website() -> FileResponse:
     """Serve the registration form."""
-    return FileResponse(website)
+    return FileResponse(register)
+
+
+@app.get("/login")
+def login_user() -> FileResponse:
+    """Serve the login form."""
+    return FileResponse(login)
 
 
 @app.post("/register")

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -6,6 +6,7 @@ emails are rejected with 409 and message. No validation is done yet.
 """
 
 import hashlib
+import hmac
 import json
 from pathlib import Path
 import secrets
@@ -32,15 +33,25 @@ register = "static/register.html"
 login = "static/login.html"
 users_file = Path("users.json")
 
+def load_users() -> list[dict[str, str]]:
+    """Load the users JSON file and return it treating a missing or corrupt file as empty."""
+    if users_file.exists():
+        try:
+            with users_file.open() as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return []
+    return []
+
 
 @app.get("/")
-def get_website() -> FileResponse:
+def get_register() -> FileResponse:
     """Serve the registration form."""
     return FileResponse(register)
 
 
 @app.get("/login")
-def login_user() -> FileResponse:
+def get_login() -> FileResponse:
     """Serve the login form."""
     return FileResponse(login)
 
@@ -86,3 +97,18 @@ def register_user(
         json.dump(users, f, indent=4)
 
     return {"email": email, "city": city}
+
+@app.post("/login")
+def login_user(payload: LoginRequest) -> dict[str, str]:
+    """Log user in."""
+    users = load_users()
+
+    for user in users:
+        if user["email"].lower() == payload.email.lower():
+            salt = bytes.fromhex(user["salt"])
+            expected_hash = bytes.fromhex(user["hash"])
+            given_hash = hashlib.pbkdf2_hmac("sha256", payload.password.encode(), salt, 100_000)
+
+            if hmac.compare_digest(given_hash, expected_hash):
+                return {"email": user["email"], "city": user["city"]}
+    raise HTTPException(status_code=401, detail="Incorrect email or password.")

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -26,7 +26,7 @@ from pydantic import EmailStr
 app = FastAPI()
 
 
-class LoginRequest(BaseModel):  # type: ignore[explicit-any]
+class LoginRequest(BaseModel): # type: ignore[explicit-any]
     """Shape of the JSON request body."""
 
     email: EmailStr

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -12,26 +12,30 @@ from pathlib import Path
 import secrets
 from typing import Annotated
 
-from pydantic import BaseModel
-from pydantic import EmailStr
 from email_validator import EmailNotValidError
 from email_validator import validate_email
 from fastapi import FastAPI
 from fastapi import Form
 from fastapi import HTTPException
 from fastapi.responses import FileResponse
+from pydantic import BaseModel
+from pydantic import EmailStr
 
 # create FastAPI app
 app = FastAPI()
 
+
 class LoginRequest(BaseModel):
     """Shape of the JSON request body."""
+
     email: EmailStr
     password: str
+
 
 register = "static/register.html"
 login = "static/login.html"
 users_file = Path("users.json")
+
 
 def load_users() -> list[dict[str, str]]:
     """Load the users JSON file and return it treating a missing or corrupt file as empty."""
@@ -97,6 +101,7 @@ def register_user(
         json.dump(users, f, indent=4)
 
     return {"email": email, "city": city}
+
 
 @app.post("/login")
 def login_user(payload: LoginRequest) -> dict[str, str]:

--- a/warmup/03_webapp/main.py
+++ b/warmup/03_webapp/main.py
@@ -26,7 +26,7 @@ from pydantic import EmailStr
 app = FastAPI()
 
 
-class LoginRequest(BaseModel): # type: ignore[explicit-any]
+class LoginRequest(BaseModel):  # type: ignore[explicit-any]
     """Shape of the JSON request body."""
 
     email: EmailStr

--- a/warmup/03_webapp/static/login.html
+++ b/warmup/03_webapp/static/login.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<input id = "email" type="email" placeholder="email" />
+<input id = "password" type="password" placeholder="password">
+<button onclick="doLogin()">Login</button>
+<div id="result"></div>
+
+<script>
+
+    async function doLogin() {
+        // read what the user typed.
+        const email = document.getElementById("email").value;
+        const password = document.getElementById("password").value;
+
+        // send the request ourselves
+        const response = await fetch("/login", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({email: email, password: password})
+        });
+
+        // the answer is here and the page has not moved.
+        const data = await response.json();
+        const box = document.getElementById("result");
+
+        if (response.status === 200) {
+            box.textContent = "Welcome" + data.email;
+        } else {
+            box.textContent = data.detail;
+        }
+    }
+</script>
+
+</html>

--- a/warmup/03_webapp/static/login.html
+++ b/warmup/03_webapp/static/login.html
@@ -25,7 +25,7 @@
         const box = document.getElementById("result");
 
         if (response.status === 200) {
-            box.textContent = "Welcome" + data.email;
+            box.textContent = "Welcome " + data.email;
         } else {
             box.textContent = data.detail;
         }


### PR DESCRIPTION
## What this changes

Adds a login page that calls `POST /login` with JSON (fetch, not form), a `LoginRequest` pydantic model, and a `POST /login` endpoint that verifies submitted password against stored hash and salt using `hmac.compare_digest`, returning `200` or `401`.

Closes #5 

## How I tested it

1. Opened `http://127.0.0.1:8000/login` and logged in with a registered user, got back `200` with `"Welcome <email>"` shown on the page, no navigation away:
<img width="390" height="124" alt="Screenshot 2026-09-02 at 6 03 59 pm" src="https://github.com/user-attachments/assets/f3062b24-abe8-40fb-b4f1-a35ae623e25b" />

2. Tried the same email with a deliberately wrong password, got `401` with `"incorrect email or password"`:
<img width="364" height="112" alt="Screenshot 2026-09-02 at 6 04 56 pm" src="https://github.com/user-attachments/assets/83fb9540-03c5-4760-aff4-0f988b08b2b9" />

3. Checked all cases in the **Network** tab, which confirms the actual status code not just the message text in the body:
<img width="893" height="329" alt="Screenshot 2026-09-02 at 6 06 33 pm" src="https://github.com/user-attachments/assets/b49bfe7f-e0cc-452c-b6fa-0bbfc5cc61cf" />

4. In `/docs`, sent a request with the password field missing entirely, got `422` with `"Field required"` for password, generated automatically by the `LoginRequest`  model with no validation code written:
<img width="315" height="414" alt="Screenshot 2026-09-02 at 6 14 13 pm" src="https://github.com/user-attachments/assets/00e00d62-07aa-495e-a791-6a
<img width="384" height="351" alt="Screenshot 2026-09-02 at 6 14 33 pm" src="https://github.com/user-attachments/assets/91cd76bb-3ec5-47a6-b3d3-35805966bd28" />
f1dc294dba" />

5. Compared **Content-Type** in the **Network** tab **Request Headers**:
<img width="325" height="40" alt="Screenshot 2026-09-02 at 6 19 00 pm" src="https://github.com/user-attachments/assets/3f0a8cb0-dfdb-4893-8e28-cc45a6db6f27" />
<img width="504" height="112" alt="Screenshot 2026-09-02 at 6 20 21 pm" src="https://github.com/user-attachments/assets/84e1ee8e-2aa1-4e15-ab3d-4dd1bda32ac0" />

## Anything I was unsure about

- Sending a non email string ("asdfds") in the email field returns a `422` with a structured array in 'detail', and the given front end `JS box.textContent = data.detail` renders that as `[object Object]` instead of readable text. Left the JS as given by the ticket said to type it out as is but I'm flagging it as I found it through testing
- I didn't get the updating `README` step, in terms of which file to put or create a new one (no session/token). I documented the step explicitly in a new `README.md` in `/warmup/03_webapp/` rather than leaving it in the original.

## Checklist

- [x] I can explain every line in this pull request out loud
- [x] No passwords, keys or personal data, and no data files committed
- [x] `ruff check .` is clean
- [x] No `print()` left behind
- [x] Every acceptance criterion on the ticket is ticked